### PR TITLE
Update RefundRequest.php

### DIFF
--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -45,7 +45,7 @@ class RefundRequest extends AbstractRestRequest
         // Australian dollars.
         $this->validate('amount', 'transactionReference');
         $data = array(
-            'amount'         => $this->getAmount(),
+            'amount'         => $this->getAmountInteger(),
             'transaction_id' => $this->getTransactionReference(),
             'reference'      => $this->getTransactionReference() . '-REFUND',
         );


### PR DESCRIPTION
Wrong refunded amount.

Steps to replicate:

- refund an amount of $99.00

Expected result:

- amount sent should be 9900 not 99.00, as fatzebra will think that you were trying to transact an amount with $0.99